### PR TITLE
Improvements to the 2.2 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+*.sw[a-z]
 .vagrant
-tmp/
+employees.tgz
+hadoop-*.tar.gz
+hadoop-*.tar.gz.mds
+hbase-*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-*.sw[a-z]
 .vagrant
-hadoop.tar.gz
-employees.tgz

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--cpus", "1", "--memory", "512"]
   end
 
+  config.vm.synced_folder "tmp", "/vagrant"
+
   config.vm.define :hadoop1 do |hadoop1|
     hadoop1.vm.network "private_network", ip: "192.168.7.12"
     hadoop1.vm.hostname = "hadoop1.local"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--cpus", "1", "--memory", "512"]
   end
 
-  config.vm.synced_folder "tmp", "/vagrant"
-
   config.vm.define :hadoop1 do |hadoop1|
     hadoop1.vm.network "private_network", ip: "192.168.7.12"
     hadoop1.vm.hostname = "hadoop1.local"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,53 +1,50 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
+VAGRANTFILE_API_VERSION = "2"
 
-Vagrant.configure("1") do |config|
-  config.vm.box = "cascading-hadoop-base"
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
-  config.vm.define :hadoop1 do |hadoop1_config|
-    hadoop1_config.vm.network :hostonly, "192.168.7.12"
-    hadoop1_config.vm.host_name = "hadoop1.local"
-    hadoop1_config.vm.provision :puppet do |hadoop1_puppet|
-      hadoop1_puppet.manifest_file = "datanode.pp"
-      hadoop1_puppet.manifests_path = "manifests"
-      hadoop1_puppet.module_path = "modules"
-    end
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--cpus", "1", "--memory", "512"]
   end
-  
-  config.vm.define :hadoop2 do |hadoop2_config|
-    hadoop2_config.vm.network :hostonly, "192.168.7.13"
-    hadoop2_config.vm.host_name = "hadoop2.local"
-    hadoop2_config.vm.provision :puppet do |hadoop2_puppet|
-      hadoop2_puppet.manifest_file = "datanode.pp"
-      hadoop2_puppet.manifests_path = "manifests"
-      hadoop2_puppet.module_path = "modules"
-    end
-  end
-  
-  config.vm.define :hadoop3 do |hadoop3_config|
-    hadoop3_config.vm.network :hostonly, "192.168.7.14"
-    hadoop3_config.vm.host_name = "hadoop3.local"
-    hadoop3_config.vm.provision :puppet do |hadoop3_puppet|
-      hadoop3_puppet.manifest_file = "datanode.pp"
-      hadoop3_puppet.manifests_path = "manifests"
-      hadoop3_puppet.module_path = "modules"
-    end
-  end
-  
-   config.vm.define :master do |master_config|
-    master_config.vm.network :hostonly, "192.168.7.10"
-    master_config.vm.host_name = "master.local"
-    master_config.vm.provision :puppet do |master_puppet|
-      master_puppet.manifest_file = "master.pp"
-      master_puppet.manifests_path = "manifests"
-      master_puppet.module_path = "modules"
+
+  config.vm.define :hadoop1 do |hadoop1|
+    hadoop1.vm.network "private_network", ip: "192.168.7.12"
+    hadoop1.vm.hostname = "hadoop1.local"
+
+    config.vm.provision :puppet do |puppet|
+      puppet.manifest_file = "datanode.pp"
+      puppet.module_path = "modules"
     end
   end
 
-end
+  config.vm.define :hadoop2 do |hadoop2|
+    hadoop2.vm.network "private_network", ip: "192.168.7.13"
+    hadoop2.vm.hostname = "hadoop2.local"
 
-Vagrant.configure("2") do |config|
-    config.vm.provider :virtualbox do |vb|
-        vb.customize ["modifyvm", :id, "--memory", "512"]
+    config.vm.provision :puppet do |puppet|
+      puppet.manifest_file = "datanode.pp"
+      puppet.module_path = "modules"
     end
+  end
+
+  config.vm.define :hadoop3 do |hadoop3|
+    hadoop3.vm.network "private_network", ip: "192.168.7.14"
+    hadoop3.vm.hostname = "hadoop3.local"
+
+    config.vm.provision :puppet do |puppet|
+      puppet.manifest_file = "datanode.pp"
+      puppet.module_path = "modules"
+    end
+  end
+
+  config.vm.define :master, primary: true do |master|
+    master.vm.network "private_network", ip: "192.168.7.10"
+    master.vm.hostname = "master.local"
+
+    config.vm.provision :puppet do |puppet|
+      puppet.manifest_file = "master.pp"
+      puppet.module_path = "modules"
+    end
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,10 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "precise64"
+  config.vm.box = "cascading-hadoop-base"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   config.vm.provider :virtualbox do |vb|

--- a/modules/hbase/manifests/init.pp
+++ b/modules/hbase/manifests/init.pp
@@ -1,5 +1,5 @@
 class hbase {
-  $hbase_version = "0.94.13"
+  $hbase_version = "0.94.15"
   $hbase_home = "/opt/hbase-${hbase_version}"
   $hbase_tarball = "hbase-${hbase_version}.tar.gz"
 
@@ -48,7 +48,7 @@ class hbase {
       group => root,
       require => Exec["unpack_hbase"]
   }
-  
+
   file { "/etc/profile.d/hbase-path.sh":
     content => template("hbase/hbase-path.sh.erb"),
     owner => root,


### PR DESCRIPTION
Cascading! We're relying on this awesome project to bootstrap a local, but distributed test environment and I came across a few trivial improvements that we did in our fork and saw no harm in putting in a PR:
- Bump HBase to 0.94.15 as 0.94.13 is nowhere to be found (at least on the mirrors closest to us)
- Upgrade Vagrantfile to the V2 Configuration API and add `vm_box_url` so a simple `vagrant up` does the job even if the precise64 box is not available yet
- Share the tarballs across the VMs through a `tmp` directory instead of the project root and ignore, so that the git repository stays clean
- Clean unnecessary git ignores

More than happy to do the same when 2.5 is official/stable. We're also planning on adding Pig to the mix through a new module.

Thanks for the awesome work!
