### PR TITLE
add Spark to the cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.sw[a-z]
 .vagrant
 employees.tgz
@@ -6,4 +7,4 @@ hadoop-*.tar.gz.mds
 hbase-*.tar.gz
 spark-*.tgz
 apache-hive-*.tar.gz
-
+phoenix-*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ hadoop-*.tar.gz
 hadoop-*.tar.gz.mds
 hbase-*.tar.gz
 spark-*.tgz
+apache-hive-*.tar.gz
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ employees.tgz
 hadoop-*.tar.gz
 hadoop-*.tar.gz.mds
 hbase-*.tar.gz
+spark-*.tgz

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The setup is fully distributed. `hadoop1`, `hadoop2` and `hadoop3` are running a
 [zookeeper](http://zookeeper.apache.org) instance and a region-server each. The HBase master is running on the `master`
 VM.
 
-The webinterface of the HBase master is http://master.local:60010.
+The webinterface of the HBase master is http://master.local:16010.
 
 ## Hacking & Troubleshooting & Tips & Tricks
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ This will set up 4 machines - `master`, `hadoop1`, `hadoop2` and `hadoop3`. Each
 RAM. If this is too much for your machine, adjust the `Vagrantfile`.
 
 The machines will be provisioned using [Puppet](http://puppetlabs.com/). All of them will have hadoop
-(apache-hadoop-2.6.0) installed, ssh will be configured and local name resolution also works.
+(apache-hadoop-2.7.1) installed, ssh will be configured and local name resolution also works.
 
-Hadoop is installed in `/opt/hadoop-2.6.0` and all tools are in the `PATH`.
+Hadoop is installed in `/opt/hadoop-2.7.1` and all tools are in the `PATH`.
 
 The `master` machine acts as the namenode and the yarn resource manager, the 3 others are data nodes and run node
 managers.
@@ -58,7 +58,7 @@ is required.
 
 ### Starting the cluster
 
-This cluster uses the `ssh-into-all-the-boxes-and-start-things-up`-approach, which is fine for testing.
+This cluster uses the `ssh`-into-all-the-boxes-and-start-things-up-approach, which is fine for testing.
 
 Once all machines are up and provisioned, the cluster can be started. Log into the master, format hdfs and start the
 cluster.
@@ -131,7 +131,7 @@ the `PATH`. The SDK itself can be found in `/opt/CascadingSDK`.
 
 ### Driven
 
-The SDK allows you to install the [Driven plugin for Cascading]((http://cascading.io/driven) , by simply running
+The SDK allows you to install the [Driven plugin for Cascading](http://cascading.io/driven) , by simply running
 `install-driven-plugin`. This will install the plugin for the vagrant user in `/home/vagrant/.cascading/.driven-plugin`.
 
 Installing the plugin will cause every Cascading based application to send telemetry to `https://driven.cascading.io`.

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ start up a new cluster.
 
 You can access all services of the cluster with your web-browser.
 
-* namenode: http://master.local:50070/dfshealth.jsp
-* application master: http://master.local:8088/cluster
-* job history server: http://master.local:19888/jobhistory
+* namenode: http://master.local:50070/
+* application master: http://master.local:8088/
+* job history server: http://master.local:19888/
 
 ### Command line
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--cpus", "1", "--memory", "512"]
+    vb.customize ["modifyvm", :id, "--cpus", "1", "--memory", "1024"]
   end
 
   config.vm.provider "vmware_fusion" do |v, override|
@@ -50,6 +50,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define :master, primary: true do |master|
     master.vm.network "private_network", ip: "192.168.7.10"
     master.vm.hostname = "master.local"
+
+    config.vm.synced_folder "/home/ggbaker/crs/732", "/home/vagrant/732"
 
     config.vm.provision :puppet do |puppet|
       puppet.manifest_file = "master.pp"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--cpus", "1", "--memory", "1024"]
+    vb.customize ["modifyvm", :id, "--cpus", "1", "--memory", "512"]
   end
 
   config.vm.provider "vmware_fusion" do |v, override|
@@ -50,8 +50,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define :master, primary: true do |master|
     master.vm.network "private_network", ip: "192.168.7.10"
     master.vm.hostname = "master.local"
-
-    config.vm.synced_folder "/home/ggbaker/crs/732", "/home/vagrant/732"
 
     config.vm.provision :puppet do |puppet|
       puppet.manifest_file = "master.pp"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,16 +4,15 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "cascading-hadoop-base"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "larryli/vivid64"
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--cpus", "1", "--memory", "512"]
+    vb.customize ["modifyvm", :id, "--cpus", "1", "--memory", "1024"]
   end
 
   config.vm.provider "vmware_fusion" do |v, override|
       override.vm.box_url = "http://files.vagrantup.com/precise64_vmware.box"
-      v.vmx["memsize"] = "512"
+      v.vmx["memsize"] = "1024"
       v.vmx["numvcpus"] = "1"
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     hadoop1.vm.network "private_network", ip: "192.168.7.12"
     hadoop1.vm.hostname = "hadoop1.local"
 
-    config.vm.provision :puppet do |puppet|
+    hadoop1.vm.provision :puppet do |puppet|
       puppet.manifest_file = "datanode.pp"
       puppet.module_path = "modules"
     end
@@ -31,7 +31,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     hadoop2.vm.network "private_network", ip: "192.168.7.13"
     hadoop2.vm.hostname = "hadoop2.local"
 
-    config.vm.provision :puppet do |puppet|
+    hadoop2.vm.provision :puppet do |puppet|
       puppet.manifest_file = "datanode.pp"
       puppet.module_path = "modules"
     end
@@ -41,7 +41,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     hadoop3.vm.network "private_network", ip: "192.168.7.14"
     hadoop3.vm.hostname = "hadoop3.local"
 
-    config.vm.provision :puppet do |puppet|
+    hadoop3.vm.provision :puppet do |puppet|
       puppet.manifest_file = "datanode.pp"
       puppet.module_path = "modules"
     end
@@ -51,7 +51,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     master.vm.network "private_network", ip: "192.168.7.10"
     master.vm.hostname = "master.local"
 
-    config.vm.provision :puppet do |puppet|
+    master.vm.provision :puppet do |puppet|
       puppet.manifest_file = "master.pp"
       puppet.module_path = "modules"
     end

--- a/manifests/datanode.pp
+++ b/manifests/datanode.pp
@@ -1,5 +1,6 @@
 include base
 include hadoop
 include hbase
+include phoenix
 include spark
 include avahi

--- a/manifests/datanode.pp
+++ b/manifests/datanode.pp
@@ -1,4 +1,5 @@
 include base
 include hadoop
 include hbase
+include spark
 include avahi

--- a/manifests/master-single.pp
+++ b/manifests/master-single.pp
@@ -11,7 +11,7 @@ class{ 'hbase':
 
 include hbase
 #include hive
-#include phoenix
+include phoenix
 include spark
 include avahi
 include cascading

--- a/manifests/master-single.pp
+++ b/manifests/master-single.pp
@@ -10,6 +10,8 @@ class{ 'hbase':
 }
 
 include hbase
+#include hive
+#include phoenix
 include spark
 include avahi
 include cascading

--- a/manifests/master-single.pp
+++ b/manifests/master-single.pp
@@ -6,5 +6,6 @@ class{ 'hadoop':
 }
 
 #include hbase
+include spark
 include avahi
 include cascading

--- a/manifests/master-single.pp
+++ b/manifests/master-single.pp
@@ -4,8 +4,12 @@ class{ 'hadoop':
   slaves_file => "puppet:///modules/hadoop/slaves-single",
   hdfs_site_file => "puppet:///modules/hadoop/hdfs-site-single.xml"
 }
+class{ 'hbase':
+  regionservers_file => "puppet:///modules/hbase/regionservers-single",
+  hbase_site_file => "puppet:///modules/hbase/hbase-site-single.xml"
+}
 
-#include hbase
+include hbase
 include spark
 include avahi
 include cascading

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -1,6 +1,7 @@
 include base
 include hadoop
 include hbase
+include hive
 include spark
 include avahi
 include cascading

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -1,5 +1,6 @@
 include base
 include hadoop
 include hbase
+include spark
 include avahi
 include cascading

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -2,7 +2,7 @@ include base
 include hadoop
 include hbase
 #include hive
-#include phoenix
+include phoenix
 include spark
 include avahi
 include cascading

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -1,7 +1,8 @@
 include base
 include hadoop
 include hbase
-include hive
+#include hive
+#include phoenix
 include spark
 include avahi
 include cascading

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -6,7 +6,7 @@ class base{
     command => '/usr/bin/apt-get update',
   }
 
-  package { "openjdk-6-jdk" :
+  package { "openjdk-7-jdk" :
     ensure => present,
     require => Exec['apt-get update']
   }

--- a/modules/cascading/files/ccsdk.sh
+++ b/modules/cascading/files/ccsdk.sh
@@ -1,4 +1,4 @@
-export JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64
+export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
 export CASCADING_SDK_HOME=/opt/CascadingSDK
 
 . $CASCADING_SDK_HOME/etc/setenv.sh

--- a/modules/cascading/manifests/init.pp
+++ b/modules/cascading/manifests/init.pp
@@ -10,7 +10,7 @@ class cascading{
     # S3 can be slow at times hence a longer timeout
     timeout => 1800,
     unless => "ls /opt | grep CascadingSDK",
-    require => Package["openjdk-6-jdk"]
+    require => Package["openjdk-7-jdk"]
   }
 
   exec { "unpack_sdk" :

--- a/modules/hadoop/files/hadoop-env.sh
+++ b/modules/hadoop/files/hadoop-env.sh
@@ -24,7 +24,7 @@
 # remote nodes.
 
 # The java implementation to use.
-export JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64
+export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
 
 # The jsvc implementation to use. Jsvc is required to run secure datanodes.
 #export JSVC_HOME=${JSVC_HOME}

--- a/modules/hadoop/files/hdfs-site-single.xml
+++ b/modules/hadoop/files/hdfs-site-single.xml
@@ -7,7 +7,7 @@
   <description>The actual number of replications can be specified when the file is created.</description>
  </property>
 <property>
-  <name>dfs.permissions</name>
+  <name>dfs.permissions.enabled</name>
   <value>false</value>
   <description>
     If "true", enable permission checking in HDFS.
@@ -18,11 +18,11 @@
   </description>
 </property>
 <property>
-    <name>dfs.data.dir</name>
+    <name>dfs.datanode.data.dir</name>
     <value>/srv/hadoop/datanode</value>
 </property>
 <property>
-    <name>dfs.name.dir</name>
+    <name>dfs.namenode.name.dir</name>
     <value>/srv/hadoop/namenode</value>
 </property>
 </configuration>

--- a/modules/hadoop/files/hdfs-site.xml
+++ b/modules/hadoop/files/hdfs-site.xml
@@ -7,7 +7,7 @@
   <description>The actual number of replications can be specified when the file is created.</description>
  </property>
 <property>
-  <name>dfs.permissions</name>
+  <name>dfs.permissions.enabled</name>
   <value>false</value>
   <description>
     If "true", enable permission checking in HDFS.
@@ -18,11 +18,11 @@
   </description>
 </property>
 <property>
-    <name>dfs.data.dir</name>
+    <name>dfs.datanode.data.dir</name>
     <value>/srv/hadoop/datanode</value>
 </property>
 <property>
-    <name>dfs.name.dir</name>
+    <name>dfs.namenode.name.dir</name>
     <value>/srv/hadoop/namenode</value>
 </property>
 </configuration>

--- a/modules/hadoop/files/hdfs-site.xml
+++ b/modules/hadoop/files/hdfs-site.xml
@@ -3,7 +3,7 @@
 <configuration>
  <property>
   <name>dfs.replication</name>
-  <value>3</value>
+  <value>2</value>
   <description>The actual number of replications can be specified when the file is created.</description>
  </property>
 <property>

--- a/modules/hadoop/files/mapred-site.xml
+++ b/modules/hadoop/files/mapred-site.xml
@@ -26,4 +26,17 @@
      <name>mapreduce.framework.name</name>
      <value>yarn</value>
  </property>
+ 
+ <property>
+    <name>mapreduce.jobtracker.staging.root.dir</name>
+    <value>/user</value>
+ </property>
+ <property>
+    <name>mapred.system.dir</name>
+    <value>/user/${user.name}/.staging</value>
+ </property>
+     <property>
+    <name>yarn.app.mapreduce.am.staging-dir</name>
+    <value>/user</value>
+ </property>
 </configuration>

--- a/modules/hadoop/files/mapred-site.xml
+++ b/modules/hadoop/files/mapred-site.xml
@@ -26,17 +26,4 @@
      <name>mapreduce.framework.name</name>
      <value>yarn</value>
  </property>
- 
- <property>
-    <name>mapreduce.jobtracker.staging.root.dir</name>
-    <value>/user</value>
- </property>
- <property>
-    <name>mapred.system.dir</name>
-    <value>/user/${user.name}/.staging</value>
- </property>
-     <property>
-    <name>yarn.app.mapreduce.am.staging-dir</name>
-    <value>/user</value>
- </property>
 </configuration>

--- a/modules/hadoop/manifests/init.pp
+++ b/modules/hadoop/manifests/init.pp
@@ -41,7 +41,7 @@ class hadoop($slaves_file = undef, $hdfs_site_file = undef) {
     timeout => 1800,
     path => $path,
     creates => "/vagrant/$hadoop_tarball",
-    require => [ Package["openjdk-6-jdk"], Exec["download_grrr"]]
+    require => [ Package["openjdk-7-jdk"], Exec["download_grrr"]]
   }
 
   exec { "download_checksum":

--- a/modules/hadoop/manifests/init.pp
+++ b/modules/hadoop/manifests/init.pp
@@ -1,6 +1,6 @@
 class hadoop($slaves_file = undef, $hdfs_site_file = undef) {
 
-  $hadoop_version = "2.6.0"
+  $hadoop_version = "2.7.1"
   $hadoop_home = "/opt/hadoop-${hadoop_version}"
   $hadoop_tarball = "hadoop-${hadoop_version}.tar.gz"
   $hadoop_tarball_checksums = "${hadoop_tarball}.mds"

--- a/modules/hadoop/manifests/init.pp
+++ b/modules/hadoop/manifests/init.pp
@@ -1,6 +1,6 @@
 class hadoop($slaves_file = undef, $hdfs_site_file = undef) {
 
-  $hadoop_version = "2.7.1"
+  $hadoop_version = "2.7.2"
   $hadoop_home = "/opt/hadoop-${hadoop_version}"
   $hadoop_tarball = "hadoop-${hadoop_version}.tar.gz"
   $hadoop_tarball_checksums = "${hadoop_tarball}.mds"

--- a/modules/hadoop/templates/hadoop-path.sh.erb
+++ b/modules/hadoop/templates/hadoop-path.sh.erb
@@ -1,10 +1,10 @@
 export HADOOP_HOME_WARN_SUPPRESS="true"
-export HADOOP_HOME=<%=hadoop_home%>
+export HADOOP_HOME=<%= @hadoop_home %>
 export HADOOP_YARN_HOME=$HADOOP_HOME
 export HADOOP_PREFIX=$HADOOP_HOME
-export HADOOP_CONF_DIR=<%=hadoop_conf_dir%>
-export YARN_CONF_DIR=<%=hadoop_conf_dir%>
+export HADOOP_CONF_DIR=<%= @hadoop_conf_dir %>
+export YARN_CONF_DIR=<%= @hadoop_conf_dir %>
 export PATH=$HADOOP_HOME/bin:$PATH
-export YARN_LOG_DIR=<%=yarn_log_dir%>
-export HADOOP_LOG_DIR=<%=hadoop_log_dir%>
-export HADOOP_MAPRED_LOG_DIR=<%=mapred_log_dir%>
+export YARN_LOG_DIR=<%= @yarn_log_dir %>
+export HADOOP_LOG_DIR=<%= @hadoop_log_dir %>
+export HADOOP_MAPRED_LOG_DIR=<%= @mapred_log_dir %>

--- a/modules/hbase/files/hbase-env.sh
+++ b/modules/hbase/files/hbase-env.sh
@@ -27,7 +27,7 @@
 
 # The java implementation to use.  Java 1.6 required.
 # export JAVA_HOME=/usr/java/jdk1.6.0/
-export JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64
+export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
 # Extra Java CLASSPATH elements.  Optional.
 # export HBASE_CLASSPATH=
 

--- a/modules/hbase/files/hbase-site-single.xml
+++ b/modules/hbase/files/hbase-site-single.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>hbase.zookeeper.quorum</name>
+    <value>master.local</value>
+  </property>
+  <property>
+    <name>hbase.zookeeper.property.dataDir</name>
+    <value>/srv/zookeeper</value>
+    <description>Property from ZooKeeper's config zoo.cfg.  The directory where the snapshot is stored.  </description>
+  </property>
+  <property>
+    <name>hbase.rootdir</name>
+    <value>hdfs://master.local:9000/hbase</value>
+    <description>The directory shared by RegionServers.</description>
+  </property>
+  <property>
+    <name>hbase.cluster.distributed</name>
+    <value>false</value>
+    <description>The mode the cluster will be in. Possible values are
+      false: standalone and pseudo-distributed setups with managed Zookeeper
+      true: fully-distributed with unmanaged Zookeeper Quorum (see hbase-env.sh)
+    </description>
+  </property>
+  <property>
+    <name>dfs.replication</name>
+    <value>1</value>
+  </property>
+</configuration>

--- a/modules/hbase/files/hbase-site.xml
+++ b/modules/hbase/files/hbase-site.xml
@@ -23,4 +23,8 @@
       true: fully-distributed with unmanaged Zookeeper Quorum (see hbase-env.sh)
     </description>
   </property>
+  <property>
+    <name>dfs.replication</name>
+    <value>2</value>
+  </property>
 </configuration>

--- a/modules/hbase/files/regionservers-single
+++ b/modules/hbase/files/regionservers-single
@@ -1,0 +1,1 @@
+master.local

--- a/modules/hbase/manifests/init.pp
+++ b/modules/hbase/manifests/init.pp
@@ -13,7 +13,7 @@ class hbase {
     timeout => 1800,
     path => $path,
     creates => "/vagrant/$hbase_tarball",
-    require => [ Package["openjdk-6-jdk"], Exec["download_grrr"]]
+    require => [ Package["openjdk-7-jdk"], Exec["download_grrr"]]
   }
 
   exec { "unpack_hbase" :

--- a/modules/hbase/manifests/init.pp
+++ b/modules/hbase/manifests/init.pp
@@ -1,8 +1,7 @@
 class hbase {
-  $hbase_version = "0.98.13"
-  $hbase_platform = "hadoop2"
-  $hbase_home = "/opt/hbase-${hbase_version}-${hbase_platform}"
-  $hbase_tarball = "hbase-${hbase_version}-${hbase_platform}-bin.tar.gz"
+  $hbase_version = "1.1.1"
+  $hbase_home = "/opt/hbase-${hbase_version}"
+  $hbase_tarball = "hbase-${hbase_version}-bin.tar.gz"
 
   file { "/srv/zookeeper":
     ensure => "directory"

--- a/modules/hbase/manifests/init.pp
+++ b/modules/hbase/manifests/init.pp
@@ -1,7 +1,20 @@
-class hbase {
+class hbase($regionservers_file = undef, $hbase_site_file = undef) {
   $hbase_version = "1.1.1"
   $hbase_home = "/opt/hbase-${hbase_version}"
   $hbase_tarball = "hbase-${hbase_version}-bin.tar.gz"
+
+  if $regionservers_file == undef {
+    $_regionservers_file = "puppet:///modules/hbase/regionservers_file"
+  }
+  else {
+    $_regionservers_file = $regionservers_file
+  }
+  if $hbase_site_file == undef {
+    $_hbase_site_file = "puppet:///modules/hbase/hbase-site.xml"
+  }
+  else {
+    $_hbase_site_file = $hbase_site_file
+  }
 
   file { "/srv/zookeeper":
     ensure => "directory"
@@ -24,7 +37,7 @@ class hbase {
 
   file {
     "${hbase_home}/conf/regionservers":
-      source => "puppet:///modules/hbase/regionservers",
+      source => $_regionservers_file,
       mode => 644,
       owner => root,
       group => root,
@@ -33,7 +46,7 @@ class hbase {
 
   file {
     "${hbase_home}/conf/hbase-site.xml":
-      source => "puppet:///modules/hbase/hbase-site.xml",
+      source => $_hbase_site_file,
       mode => 644,
       owner => root,
       group => root,

--- a/modules/hbase/manifests/init.pp
+++ b/modules/hbase/manifests/init.pp
@@ -1,5 +1,5 @@
 class hbase($regionservers_file = undef, $hbase_site_file = undef) {
-  $hbase_version = "1.1.1"
+  $hbase_version = "1.2.2"
   $hbase_home = "/opt/hbase-${hbase_version}"
   $hbase_tarball = "hbase-${hbase_version}-bin.tar.gz"
 

--- a/modules/hbase/manifests/init.pp
+++ b/modules/hbase/manifests/init.pp
@@ -4,7 +4,7 @@ class hbase($regionservers_file = undef, $hbase_site_file = undef) {
   $hbase_tarball = "hbase-${hbase_version}-bin.tar.gz"
 
   if $regionservers_file == undef {
-    $_regionservers_file = "puppet:///modules/hbase/regionservers_file"
+    $_regionservers_file = "puppet:///modules/hbase/regionservers"
   }
   else {
     $_regionservers_file = $regionservers_file

--- a/modules/hbase/manifests/init.pp
+++ b/modules/hbase/manifests/init.pp
@@ -25,7 +25,7 @@ class hbase($regionservers_file = undef, $hbase_site_file = undef) {
     timeout => 1800,
     path => $path,
     creates => "/vagrant/$hbase_tarball",
-    require => [ Package["openjdk-6-jdk"], Exec["download_grrr"]]
+    require => [ Package["openjdk-7-jdk"], Exec["download_grrr"]]
   }
 
   exec { "unpack_hbase" :

--- a/modules/hbase/templates/hbase-path.sh.erb
+++ b/modules/hbase/templates/hbase-path.sh.erb
@@ -1,3 +1,3 @@
-export HBASE_HOME=<%=hbase_home%>
+export HBASE_HOME=<%= @hbase_home %>
 export HBASE_CONF_DIR=$HBASE_HOME/conf
 export PATH=$HBASE_HOME/bin:$PATH

--- a/modules/hive/files/prepare-hive.sh
+++ b/modules/hive/files/prepare-hive.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+. /etc/profile
+
+export HDFS_USER=hdfs
+
+su - $HDFS_USER -c "$HADOOP_PREFIX/bin/hadoop fs -mkdir -p /tmp /user/hive/warehouse; $HADOOP_PREFIX/bin/hadoop fs -chmod g+w /tmp /user/hive/warehouse"

--- a/modules/hive/manifests/init.pp
+++ b/modules/hive/manifests/init.pp
@@ -1,5 +1,5 @@
 class hive {
-  $hive_version = "1.2.1"
+  $hive_version = "2.1.0"
   $hive_tarball = "apache-hive-${hive_version}-bin.tar.gz"
   $hive_home = "/opt/apache-hive-${hive_version}-bin"
 

--- a/modules/hive/manifests/init.pp
+++ b/modules/hive/manifests/init.pp
@@ -23,5 +23,14 @@ class hive {
     owner => vagrant,
     group => root,
   }
+  
+  file {
+    "${hive_home}/bin/prepare-hive.sh":
+      source => "puppet:///modules/hive/prepare-hive.sh",
+      mode => 755,
+      owner => vagrant,
+      group => root,
+      require => Exec["unpack_hive"]
+  }
 
 }

--- a/modules/hive/manifests/init.pp
+++ b/modules/hive/manifests/init.pp
@@ -1,5 +1,5 @@
 class hive {
-  $hive_version = "1.1.1"
+  $hive_version = "1.2.1"
   $hive_tarball = "apache-hive-${hive_version}-bin.tar.gz"
   $hive_home = "/opt/apache-hive-${hive_version}-bin"
 
@@ -15,7 +15,7 @@ class hive {
     command => "tar xf /vagrant/${hive_tarball} -C /opt",
     path => $path,
     creates => "${hive_home}",
-    require => Exec["download_hive"]
+    require => Exec["download_hive", "unpack_hadoop"]
   }
 
   file { "/etc/profile.d/hive-path.sh":

--- a/modules/hive/manifests/init.pp
+++ b/modules/hive/manifests/init.pp
@@ -1,0 +1,27 @@
+class hive {
+  $hive_version = "1.1.1"
+  $hive_tarball = "apache-hive-${hive_version}-bin.tar.gz"
+  $hive_home = "/opt/apache-hive-${hive_version}-bin"
+
+  exec { "download_hive":
+    command => "/tmp/grrr hive/hive-${hive_version}/apache-hive-${hive_version}-bin.tar.gz -O /vagrant/$hive_tarball --read-timeout=5 --tries=0",
+    timeout => 1800,
+    path => $path,
+    creates => "/vagrant/$hive_tarball",
+    require => [ Exec["download_grrr"]]
+  }
+
+  exec { "unpack_hive" :
+    command => "tar xf /vagrant/${hive_tarball} -C /opt",
+    path => $path,
+    creates => "${hive_home}",
+    require => Exec["download_hive"]
+  }
+
+  file { "/etc/profile.d/hive-path.sh":
+    content => template("hive/hive-path.sh.erb"),
+    owner => vagrant,
+    group => root,
+  }
+
+}

--- a/modules/hive/templates/hive-path.sh.erb
+++ b/modules/hive/templates/hive-path.sh.erb
@@ -1,2 +1,2 @@
-export HIVE_HOME=<%=hive_home%>
+export HIVE_HOME=<%= @hive_home %>
 export HADOOP_USER_CLASSPATH_FIRST=true

--- a/modules/hive/templates/hive-path.sh.erb
+++ b/modules/hive/templates/hive-path.sh.erb
@@ -1,0 +1,2 @@
+export HIVE_HOME=<%=hive_home%>
+export HADOOP_USER_CLASSPATH_FIRST=true

--- a/modules/phoenix/manifests/init.pp
+++ b/modules/phoenix/manifests/init.pp
@@ -26,5 +26,6 @@ class phoenix {
   file { "/opt/hbase-${hbase_version}/lib/${server_jar}":
     ensure => 'link',
     target => "${phoenix_home}/${server_jar}",
+    require => [ Exec["download_grrr"], Exec["unpack_hbase"] ]
   }
 }

--- a/modules/phoenix/manifests/init.pp
+++ b/modules/phoenix/manifests/init.pp
@@ -1,0 +1,32 @@
+class phoenix {
+  $phoenix_version = "4.5.1"
+  $hbase_compat = "1.1" # phoenix compatibility version
+  $hbase_version = "1.1.1" # actual installed version
+  $phoenix_tarball = "phoenix-${phoenix_version}-HBase-${hbase_compat}-bin.tar.gz"
+  $phoenix_home = "/opt/phoenix-${phoenix_version}-HBase-${hbase_compat}-bin"
+  
+  $server_jar = "phoenix-${phoenix_version}-HBase-${hbase_compat}-server.jar"
+  $client_jar = "phoenix-${phoenix_version}-HBase-${hbase_compat}-client.jar"
+
+#http://apache.mirror.iweb.ca/phoenix/phoenix-4.5.1-HBase-1.1/bin/phoenix-4.5.1-HBase-1.1-bin.tar.gz
+
+  exec { "download_phoenix":
+    command => "/tmp/grrr hive/phoenix/phoenix-${phoenix_version}-HBase-${hbase_compat}/bin/phoenix-${phoenix_version}-HBase-${hbase_compat}-bin.tar.gz -O /vagrant/$phoenix_tarball --read-timeout=5 --tries=0",
+    timeout => 1800,
+    path => $path,
+    creates => "/vagrant/${phoenix_tarball}",
+    require => [ Exec["download_grrr"]]
+  }
+
+  exec { "unpack_phoenix" :
+    command => "tar xf /vagrant/${phoenix_tarball} -C /opt",
+    path => $path,
+    creates => "${phoenix_home}",
+    require => Exec["download_phoenix", "unpack_hadoop"]
+  }
+
+  file { "/opt/hbase-${hbase_version}/lib/${server_jar}":
+    ensure => 'link',
+    target => "${phoenix_home}/${server_jar}",
+  }
+}

--- a/modules/phoenix/manifests/init.pp
+++ b/modules/phoenix/manifests/init.pp
@@ -1,7 +1,7 @@
 class phoenix {
-  $phoenix_version = "4.5.1"
+  $phoenix_version = "4.7.0"
   $hbase_compat = "1.1" # phoenix compatibility version
-  $hbase_version = "1.1.1" # actual installed version
+  $hbase_version = "1.2.2" # actual installed version
   $phoenix_tarball = "phoenix-${phoenix_version}-HBase-${hbase_compat}-bin.tar.gz"
   $phoenix_home = "/opt/phoenix-${phoenix_version}-HBase-${hbase_compat}-bin"
   

--- a/modules/phoenix/manifests/init.pp
+++ b/modules/phoenix/manifests/init.pp
@@ -8,10 +8,8 @@ class phoenix {
   $server_jar = "phoenix-${phoenix_version}-HBase-${hbase_compat}-server.jar"
   $client_jar = "phoenix-${phoenix_version}-HBase-${hbase_compat}-client.jar"
 
-#http://apache.mirror.iweb.ca/phoenix/phoenix-4.5.1-HBase-1.1/bin/phoenix-4.5.1-HBase-1.1-bin.tar.gz
-
   exec { "download_phoenix":
-    command => "/tmp/grrr hive/phoenix/phoenix-${phoenix_version}-HBase-${hbase_compat}/bin/phoenix-${phoenix_version}-HBase-${hbase_compat}-bin.tar.gz -O /vagrant/$phoenix_tarball --read-timeout=5 --tries=0",
+    command => "/tmp/grrr phoenix/phoenix-${phoenix_version}-HBase-${hbase_compat}/bin/phoenix-${phoenix_version}-HBase-${hbase_compat}-bin.tar.gz -O /vagrant/${phoenix_tarball} --read-timeout=5 --tries=0",
     timeout => 1800,
     path => $path,
     creates => "/vagrant/${phoenix_tarball}",

--- a/modules/spark/manifests/init.pp
+++ b/modules/spark/manifests/init.pp
@@ -1,0 +1,33 @@
+class spark {
+  $spark_version = "1.4.0"
+  $hadoop_version = "2.6"
+  $spark_home = "/opt/spark-${spark_version}-bin-hadoop${hadoop_version}"
+  $spark_tarball = "spark-${spark_version}-bin-hadoop${hadoop_version}.tgz"
+
+  package { "scala" :
+    ensure => present,
+    require => Exec['apt-get update']
+  }
+
+  exec { "download_spark":
+    command => "/tmp/grrr spark/spark-${spark_version}/spark-${spark_version}-bin-hadoop${hadoop_version}.tgz  -O /vagrant/$spark_tarball --read-timeout=5 --tries=0",
+    timeout => 1800,
+    path => $path,
+    creates => "/vagrant/$spark_tarball",
+    require => [ Package["scala"], Exec["download_grrr"]]
+  }
+
+  exec { "unpack_spark" :
+    command => "tar xf /vagrant/${spark_tarball} -C /opt",
+    path => $path,
+    creates => "${spark_home}",
+    require => Exec["download_spark"]
+  }
+
+  file { "/etc/profile.d/spark-path.sh":
+    content => template("spark/spark-path.sh.erb"),
+    owner => vagrant,
+    group => root,
+  }
+
+}

--- a/modules/spark/manifests/init.pp
+++ b/modules/spark/manifests/init.pp
@@ -1,7 +1,7 @@
 class spark {
-  $spark_version = "1.5.0"
-  $hadoop_version = "2.7.1" # installed Hadoop version
-  $hadoop_spark = "2.6" # Hadoop version for spark compatibility
+  $spark_version = "2.0.0"
+  $hadoop_version = "2.7.2" # installed Hadoop version
+  $hadoop_spark = "2.7" # Hadoop version for spark compatibility
   $spark_home = "/opt/spark-${spark_version}-bin-hadoop${hadoop_spark}"
   $spark_tarball = "spark-${spark_version}-bin-hadoop${hadoop_spark}.tgz"
 

--- a/modules/spark/manifests/init.pp
+++ b/modules/spark/manifests/init.pp
@@ -1,5 +1,5 @@
 class spark {
-  $spark_version = "1.4.1"
+  $spark_version = "1.5.0"
   $hadoop_version = "2.7.1" # installed Hadoop version
   $hadoop_spark = "2.6" # Hadoop version for spark compatibility
   $spark_home = "/opt/spark-${spark_version}-bin-hadoop${hadoop_spark}"

--- a/modules/spark/manifests/init.pp
+++ b/modules/spark/manifests/init.pp
@@ -1,8 +1,9 @@
 class spark {
-  $spark_version = "1.4.0"
-  $hadoop_version = "2.6"
-  $spark_home = "/opt/spark-${spark_version}-bin-hadoop${hadoop_version}"
-  $spark_tarball = "spark-${spark_version}-bin-hadoop${hadoop_version}.tgz"
+  $spark_version = "1.4.1"
+  $hadoop_version = "2.7.1" # installed Hadoop version
+  $hadoop_spark = "2.6" # Hadoop version for spark compatibility
+  $spark_home = "/opt/spark-${spark_version}-bin-hadoop${hadoop_spark}"
+  $spark_tarball = "spark-${spark_version}-bin-hadoop${hadoop_spark}.tgz"
 
   package { "scala" :
     ensure => present,
@@ -10,7 +11,7 @@ class spark {
   }
 
   exec { "download_spark":
-    command => "/tmp/grrr spark/spark-${spark_version}/spark-${spark_version}-bin-hadoop${hadoop_version}.tgz  -O /vagrant/$spark_tarball --read-timeout=5 --tries=0",
+    command => "/tmp/grrr spark/spark-${spark_version}/spark-${spark_version}-bin-hadoop${hadoop_spark}.tgz  -O /vagrant/$spark_tarball --read-timeout=5 --tries=0",
     timeout => 1800,
     path => $path,
     creates => "/vagrant/$spark_tarball",
@@ -39,7 +40,7 @@ class spark {
     require => Exec["unpack_spark"]
   }
   exec { "spark_slaves" :
-    command => "ln -s /opt/hadoop-*/etc/hadoop/slaves ${spark_home}/conf/slaves",
+    command => "ln -s /opt/hadoop-${hadoop_version}/etc/hadoop/slaves ${spark_home}/conf/slaves",
     path => $path,
     creates => "${spark_home}/conf/slaves",
     require => Exec["unpack_spark"]

--- a/modules/spark/manifests/init.pp
+++ b/modules/spark/manifests/init.pp
@@ -30,4 +30,18 @@ class spark {
     group => root,
   }
 
+  # for spark standalone mode
+  file { "${spark_home}/logs":
+    ensure => "directory",
+    owner  => "mapred",
+    group  => "mapred",
+    mode   => 755,
+    require => Exec["unpack_spark"]
+  }
+  exec { "spark_slaves" :
+    command => "ln -s /opt/hadoop-*/etc/hadoop/slaves ${spark_home}/conf/slaves",
+    path => $path,
+    creates => "${spark_home}/conf/slaves",
+    require => Exec["unpack_spark"]
+  }
 }

--- a/modules/spark/templates/spark-path.sh.erb
+++ b/modules/spark/templates/spark-path.sh.erb
@@ -1,0 +1,2 @@
+export SPARK_HOME=<%=spark_home%>
+export PATH=$SPARK_HOME/bin:$PATH

--- a/modules/spark/templates/spark-path.sh.erb
+++ b/modules/spark/templates/spark-path.sh.erb
@@ -1,2 +1,2 @@
-export SPARK_HOME=<%=spark_home%>
+export SPARK_HOME=<%= @spark_home %>
 export PATH=$SPARK_HOME/bin:$PATH

--- a/single-node/Vagrantfile
+++ b/single-node/Vagrantfile
@@ -8,15 +8,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--cpus", "2", "--memory", "2048"]
+    vb.customize ["modifyvm", :id, "--cpus", "2", "--memory", "1536"]
   end
 
   config.vm.define :master do |master|
     master.vm.network "private_network", ip: "192.168.7.10"
     master.vm.hostname = "master.local"
     
-    config.vm.synced_folder "/home/ggbaker/crs/732", "/home/vagrant/732"
-
     config.vm.provision :puppet do |puppet|
       puppet.manifest_file = "master-single.pp"
       puppet.module_path = "../modules"

--- a/single-node/Vagrantfile
+++ b/single-node/Vagrantfile
@@ -8,12 +8,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--cpus", "2", "--memory", "1536"]
+    vb.customize ["modifyvm", :id, "--cpus", "2", "--memory", "2048"]
   end
 
   config.vm.define :master do |master|
     master.vm.network "private_network", ip: "192.168.7.10"
     master.vm.hostname = "master.local"
+    
+    config.vm.synced_folder "/home/ggbaker/crs/732", "/home/vagrant/732"
 
     config.vm.provision :puppet do |puppet|
       puppet.manifest_file = "master-single.pp"

--- a/single-node/Vagrantfile
+++ b/single-node/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     master.vm.network "private_network", ip: "192.168.7.10"
     master.vm.hostname = "master.local"
     
-    config.vm.provision :puppet do |puppet|
+    master.vm.provision :puppet do |puppet|
       puppet.manifest_file = "master-single.pp"
       puppet.module_path = "../modules"
       puppet.manifests_path = "../manifests"


### PR DESCRIPTION
This adds Spark 1.4.0 to the cluster setup. I have tested it a little: spark jobs can access HDFS files (as hdfs://master.local:9000/home/vagrant/...) and jobs can be sent out to the cluster with a command like this:

```
spark-submit --master yarn-cluster ...
```

The download required during the provisioning is about 240MB: I don't know if that's enough to make you think that leaving the spark manifest commented out in manifests/master-single.pp is wise.

I haven't updated the README: again, I'm not sure if it's worth advertising there.
